### PR TITLE
mxgraph copy bugfix

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-key-handler.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-key-handler.ts
@@ -56,7 +56,6 @@ export class EditorKeyHandler {
             EditorKeyHandler.stopEvent(evt);
             if (graph.isEnabled()) {
                 const cell = mx.mxClipboard.paste(graph);
-                console.log(cell);
             }
         });
 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-key-handler.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-key-handler.ts
@@ -46,7 +46,8 @@ export class EditorKeyHandler {
         keyHandler.bindControlKey(67, (evt: KeyboardEvent) => {
             EditorKeyHandler.stopEvent(evt);
             if (graph.isEnabled()) {
-                mx.mxClipboard.copy(graph, graph.getSelectionCells());
+                const sel = EditorKeyHandler.getFilteredSelectedCells(graph);
+                mx.mxClipboard.copy(graph, sel);
             }
         });
 
@@ -54,7 +55,8 @@ export class EditorKeyHandler {
         keyHandler.bindControlKey(86, (evt: KeyboardEvent) => {
             EditorKeyHandler.stopEvent(evt);
             if (graph.isEnabled()) {
-                mx.mxClipboard.paste(graph);
+                const cell = mx.mxClipboard.paste(graph);
+                console.log(cell);
             }
         });
 
@@ -62,7 +64,8 @@ export class EditorKeyHandler {
         keyHandler.bindControlKey(88, (evt: KeyboardEvent) => {
             EditorKeyHandler.stopEvent(evt);
             if (graph.isEnabled()) {
-                mx.mxClipboard.copy(graph, graph.getSelectionCells());
+                const sel = EditorKeyHandler.getFilteredSelectedCells(graph);
+                mx.mxClipboard.copy(graph, sel);
                 EditorKeyHandler.deleteSelectedCells(graph);
             }
         });
@@ -76,8 +79,18 @@ export class EditorKeyHandler {
 
     private static deleteSelectedCells(graph: mxgraph.mxGraph): void {
         if (graph.isEnabled()) {
-          const selectedCells = graph.getSelectionCells();
+          const selectedCells = EditorKeyHandler.getFilteredSelectedCells(graph);
           graph.removeCells(selectedCells, true);
         }
-      }
+    }
+
+    private static getFilteredSelectedCells(graph: mxgraph.mxGraph): mxgraph.mxCell[] {
+        let cells = graph.getSelectionCells();
+        let parent = graph.getDefaultParent();
+
+        cells = cells.filter((cell: mxgraph.mxCell) => {
+            return cell.getParent() === parent;
+        });
+        return cells;
+    }
 }

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
@@ -123,6 +123,14 @@ export class ChangeTranslator {
         tool.name = change.child.value;
         tool.coords = { x: change.child.geometry.x, y: change.child.geometry.y };
         const node = await tool.perform();
+        if (Type.is(node, CEGNode)) {
+            const value = new ValuePair(change.child.children[0].value, change.child.children[1].value);
+            const elementValues = this.nodeNameConverter.convertFrom(value, node);
+            for (const key in elementValues) {
+                node[key] = elementValues[key];
+            }
+            await this.dataService.updateElement(node, true, Id.uuid);
+        }
         return node;
     }
 


### PR DESCRIPTION
Started fixing copy/paste bugs:
Subnodes/ Labels can no longer be copied without their parent. Name and variable of CEG Nodes are now correctly saved.