### PR TITLE
Add type to created nodes

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
@@ -165,7 +165,7 @@ export class ChangeTranslator {
         const node = await tool.perform();
         if (Type.is(node, CEGNode)) {
             const value =
-                new CEGmxModelNode(change.child.children[0].value, change.child.children[1].value, change.child.children[2].value);
+                new CEGmxModelNode(change.child.children[0].value, change.child.children[1].value, change.child.children[2].value || 'AND');
             const elementValues = this.nodeNameConverter.convertFrom(value, node);
             for (const key in elementValues) {
                 node[key] = elementValues[key];


### PR DESCRIPTION
**Behavior was:**
- Create a new CEG-node by using drag and drop
- Click on validate
- A validation error is shown that the new node does not have the required field `[type]`

**New Behavior:**
- Error is not shown, since the `type` field is set.