### PR TITLE
Mxgraph fix grid

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/editor-grid-button/components/editor-grid-button.component.css
+++ b/web/src/app/modules/views/main/editors/modules/editor-grid-button/components/editor-grid-button.component.css
@@ -1,0 +1,3 @@
+button {
+  margin-right: 0.2rem;
+}

--- a/web/src/app/modules/views/main/editors/modules/editor-grid-button/components/editor-grid-button.component.html
+++ b/web/src/app/modules/views/main/editors/modules/editor-grid-button/components/editor-grid-button.component.html
@@ -1,0 +1,4 @@
+<button *ngIf="!isGridShown" (click)="showGrid()" class="btn btn-sm btn-secondary pull-left"
+  title="{{'showGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
+<button *ngIf="isGridShown" (click)="hideGrid()" class="btn btn-sm btn-secondary pull-left"
+  title="{{'hideGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>

--- a/web/src/app/modules/views/main/editors/modules/editor-grid-button/components/editor-grid-button.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/editor-grid-button/components/editor-grid-button.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+
+@Component({
+    moduleId: module.id,
+    selector: 'editor-grid-button',
+    templateUrl: 'editor-grid-button.component.html',
+    styleUrls: ['editor-grid-button.component.css']
+})
+export class EditorGridButtonComponent {
+  public isGridShown = true;
+  public zoomFactor = 1.0;
+
+  public showGrid(): void {
+    this.isGridShown = true;
+  }
+
+  public hideGrid(): void {
+    this.isGridShown = false;
+  }
+
+  public zoomIn(): void {
+    this.zoomFactor = this.zoomFactor * 1.1;
+  }
+
+  public zoomOut(): void {
+    this.zoomFactor = this.zoomFactor / 1.1;
+  }
+
+  public resetZoom(): void {
+    this.zoomFactor = 1.0;
+  }
+
+  public getBackgroundSize(): string {
+    return (150 * this.zoomFactor) + 'px';
+  }
+
+}

--- a/web/src/app/modules/views/main/editors/modules/editor-grid-button/editor-grid-button.module.ts
+++ b/web/src/app/modules/views/main/editors/modules/editor-grid-button/editor-grid-button.module.ts
@@ -1,0 +1,24 @@
+// Angular Imports
+import { NgModule } from '@angular/core';
+
+// This Module's Components
+import { EditorGridButtonComponent } from './components/editor-grid-button.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+@NgModule({
+    imports: [
+      BrowserModule,
+      TranslateModule
+
+    ],
+    declarations: [
+        EditorGridButtonComponent,
+    ],
+    exports: [
+        EditorGridButtonComponent,
+    ]
+})
+export class EditorGridButtonModule {
+
+}

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.css
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.css
@@ -38,3 +38,17 @@ svg {
 button {
   margin-right: 0.2rem;
 }
+
+.editor-grid {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  overflow: hidden;
+}
+
+.editor-body {
+  width: 100%;
+  height: 90%;
+  position: relative;
+  overflow: auto;
+}

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
@@ -2,19 +2,16 @@
     <h5 class="card-header">{{name}}
         <div class="pull-right">
             <!-- ZOOM -->
-            <button id="editor-zoomout-button" (click)="zoomOut()" class="btn btn-sm btn-secondary pull-left"
+            <button id="editor-zoomout-button" (click)="zoomOut(); editorGridButton.zoomOut()" class="btn btn-sm btn-secondary pull-left"
                 [class.disabled]="!canZoomOut" title="{{'zoomOut' | translate}}"><i class="fa fa-search-minus"
                     aria-hidden="true"></i></button>
-            <button (click)="resetZoom()" class="btn btn-sm btn-secondary pull-left zoom-indicator"
-                title="{{'restoreZoom' | translate}}">100%</button>
-            <button id="editor-zoomin-button" (click)="zoomIn()" class="btn btn-sm btn-secondary pull-left"
+            <button (click)="resetZoom(); editorGridButton.resetZoom()" class="btn btn-sm btn-secondary pull-left zoom-indicator"
+                title="{{'restoreZoom' | translate}}">{{editorGridButton.zoomFactor * 100 | number: '1.0-0'}}%</button>
+            <button id="editor-zoomin-button" (click)="zoomIn(); editorGridButton.zoomIn()" class="btn btn-sm btn-secondary pull-left"
                 [class.disabled]="!canZoomIn" title="{{'zoomIn' | translate}}"><i class="fa fa-search-plus"
                     aria-hidden="true"></i></button>
             <!-- GRID -->
-            <button *ngIf="!isGridShown" (click)="showGrid()" class="btn btn-sm btn-secondary pull-left"
-                title="{{'showGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
-            <button *ngIf="isGridShown" (click)="hideGrid()" class="btn btn-sm btn-secondary pull-left"
-                title="{{'hideGrid' | translate}}"><i class="fa fa-th" aria-hidden="true"></i></button>
+            <editor-grid-button #editorGridButton></editor-grid-button>
             <maximize-button></maximize-button>
         </div>
     </h5>
@@ -23,10 +20,10 @@
         <div #mxGraphToolbar id="mxGraphToolbar"></div>
         <hr>
         <div class="editor-body" style="width: 100%; height: 90%; position: relative;">
-          <div id="editor-grid" *ngIf="isGridShown" style="background: url('/assets/img/grid.png'); width: 100%; height: 100%; position: absolute;"></div>
-          <div #mxGraphContainer id="mxGraphContainer" [ngClass]="{'editor-container': true}"
-            class="editor-container" style="width: 100%; height: 100%; position: absolute;"></div>
-
+          <div #mxGraphContainer id="mxGraphContainer" [ngClass]="{'editor-container': true}" class="editor-container">
+            <div id="editor-grid" class="editor-grid" [hidden]="!editorGridButton.isGridShown"
+            [ngStyle]="{'background': 'url(/assets/img/grid.png)', 'background-size': editorGridButton.getBackgroundSize()}">
+          </div>
         </div>
     </div>
 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.html
@@ -22,8 +22,12 @@
         <tool-pallette></tool-pallette>
         <div #mxGraphToolbar id="mxGraphToolbar"></div>
         <hr>
-        <div #mxGraphContainer id="mxGraphContainer" [ngClass]="{'editor-container': true, 'grid-shown': isGridShown }"
-            class="editor-container"></div>
+        <div class="editor-body" style="width: 100%; height: 90%; position: relative;">
+          <div id="editor-grid" *ngIf="isGridShown" style="background: url('/assets/img/grid.png'); width: 100%; height: 100%; position: absolute;"></div>
+          <div #mxGraphContainer id="mxGraphContainer" [ngClass]="{'editor-container': true}"
+            class="editor-container" style="width: 100%; height: 100%; position: absolute;"></div>
+
+        </div>
     </div>
 
 </div>

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -333,7 +333,6 @@ export class GraphicalEditor {
     this.undoManager = new mx.mxUndoManager(50);
     const listener = async (sender: mxgraph.mxEventSource, evt: mxgraph.mxEventObject) => {
       if (!evt.getProperty('edit').changes.some((s: object) => s.constructor.name === 'mxStyleChange')) {
-        console.log(evt.getProperty('edit'));
         this.undoManager.undoableEditHappened(evt.getProperty('edit'));
       }
     };

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -59,8 +59,6 @@ export class GraphicalEditor {
 
   private isInGraphTransition = false;
 
-  public isGridShown = true;
-
   private _model: IContainer;
   private _contents: IContainer[];
 
@@ -119,8 +117,6 @@ export class GraphicalEditor {
    * Initialize the MXGraph
    */
   private async init(): Promise<void> {
-    console.log('init');
-
     if (this.graphContainerElement === undefined) {
       return;
     }
@@ -166,6 +162,7 @@ export class GraphicalEditor {
     rubberBand.reset();
 
     this.graph.setTooltips(true);
+    this.graph.zoomFactor = 1.1;
 
     this.graph.getModel().addListener(mx.mxEvent.CHANGE, async (sender: mxgraph.mxEventSource, evt: mxgraph.mxEventObject) => {
       const edit = evt.getProperty('edit') as mxgraph.mxUndoableEdit;
@@ -535,17 +532,6 @@ export class GraphicalEditor {
 
   public resetZoom(): void {
     this.graph.zoomActual();
-  }
-
-  public showGrid(): void {
-    this.isGridShown = true;
-    // this.graphContainerElement.nativeElement.style.backgroundImage = "url('/assets/img/grid.png')";
-  }
-
-  public hideGrid(): void {
-    this.isGridShown = false;
-    // this.graphContainerElement.nativeElement.style.backgroundImage = '';
-    // this.graphContainerElement.nativeElement.style.background = 'none';
   }
 
   public get connections(): IContainer[] {

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -119,6 +119,7 @@ export class GraphicalEditor {
    * Initialize the MXGraph
    */
   private async init(): Promise<void> {
+    console.log('init');
 
     if (this.graphContainerElement === undefined) {
       return;
@@ -335,6 +336,7 @@ export class GraphicalEditor {
     this.undoManager = new mx.mxUndoManager(50);
     const listener = async (sender: mxgraph.mxEventSource, evt: mxgraph.mxEventObject) => {
       if (!evt.getProperty('edit').changes.some((s: object) => s.constructor.name === 'mxStyleChange')) {
+        console.log(evt.getProperty('edit'));
         this.undoManager.undoableEditHappened(evt.getProperty('edit'));
       }
     };
@@ -537,13 +539,13 @@ export class GraphicalEditor {
 
   public showGrid(): void {
     this.isGridShown = true;
-    this.graphContainerElement.nativeElement.style.backgroundImage = "url('/assets/img/grid.png')";
+    // this.graphContainerElement.nativeElement.style.backgroundImage = "url('/assets/img/grid.png')";
   }
 
   public hideGrid(): void {
     this.isGridShown = false;
-    this.graphContainerElement.nativeElement.style.backgroundImage = '';
-    this.graphContainerElement.nativeElement.style.background = 'none';
+    // this.graphContainerElement.nativeElement.style.backgroundImage = '';
+    // this.graphContainerElement.nativeElement.style.background = 'none';
   }
 
   public get connections(): IContainer[] {

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/graphical-editor.module.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/graphical-editor.module.ts
@@ -4,6 +4,7 @@ import { SpecmateSharedModule } from '../../../../../specmate/specmate.shared.mo
 import { MaximizeButtonModule } from '../maximize-button/maximize-button.module';
 import { ToolPalletteModule } from '../tool-pallette/tool-pallette.module';
 import { GraphicalEditor } from './components/graphical-editor.component';
+import { EditorGridButtonModule } from '../editor-grid-button/editor-grid-button.module';
 
 @NgModule({
   imports: [
@@ -11,7 +12,8 @@ import { GraphicalEditor } from './components/graphical-editor.component';
     MaximizeButtonModule,
     ToolPalletteModule,
     SpecmateSharedModule,
-    BrowserModule
+    BrowserModule,
+    EditorGridButtonModule
   ],
   declarations: [
     // COMPONENTS IN THIS MODULE

--- a/web/src/assets/scss/specmate.extensions.scss
+++ b/web/src/assets/scss/specmate.extensions.scss
@@ -191,8 +191,8 @@ textarea:focus,
 
 .editor-container {
   position: relative;
-  width: fit-content;
-  height: fit-content;
+  width: 0px;
+  height: 0px;
   min-width: 100%;
   min-height: 100%;
   overflow: auto;

--- a/web/src/assets/scss/specmate.extensions.scss
+++ b/web/src/assets/scss/specmate.extensions.scss
@@ -196,6 +196,7 @@ textarea:focus,
   min-width: 100%;
   min-height: 100%;
   overflow: auto;
+  display: table;
 }
 
 .editor-container svg {

--- a/web/src/assets/scss/specmate.extensions.scss
+++ b/web/src/assets/scss/specmate.extensions.scss
@@ -191,7 +191,14 @@ textarea:focus,
 
 .editor-container {
   position: relative;
-  width: 100%;
-  height: 90%;
+  width: fit-content;
+  height: fit-content;
+  min-width: 100%;
+  min-height: 100%;
   overflow: auto;
 }
+
+.editor-container svg {
+  position: relative;
+}
+


### PR DESCRIPTION
[Trello](https://trello.com/c/hes0LAtL/528-grid-anzeigen-initialisiert-den-graphen-jedes-mal-neu)

Showing/hiding the grid in the editor should not initialize the graph again. 
Additional, zoom-in/out also updates the grid.

Fixes also [Trello](https://trello.com/c/NmVEm4A7/527-mxgraph-die-zoomangabe-wird-nicht-aktualisiert)