### PR TITLE
Fix: Add multiple connection destroys the browser

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
@@ -95,6 +95,11 @@ export class ChangeTranslator {
         if (element === undefined) {
             return;
         }
+
+        if (change.previous === null) {
+            change.previous = '';
+        }
+
         const prevStyles: string[] = change.previous.split(';');
         const currStyles: string[] = change.style.split(';');
 


### PR DESCRIPTION
See https://trello.com/c/B0KBF9Lk/532-mxgraph-beim-hinzuf%C3%BCgen-von-mehreren-kanten-h%C3%A4ngt-sich-der-browser-auf

The reason was that we entered in an endless loop in case of exceptions while translating style changes.