### PR TITLE
Mxgraph fix undo process connection

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -295,7 +295,6 @@ export class GraphicalEditor {
       if (cell === undefined || modelElement === undefined) {
         return;
       }
-
       this.changeTranslator.retranslate(modelElement, this.graph, cell);
     });
   }
@@ -365,16 +364,17 @@ export class GraphicalEditor {
     this.undoManager = new mx.mxUndoManager(50);
     const listener = async (sender: mxgraph.mxEventSource, evt: mxgraph.mxEventObject) => {
       // StyleChanges are not added to the undo-stack, except an edge is negated (dashed line)
-      const isStyleChange = evt.getProperty('edit').changes.some((s: object) => s.constructor.name === 'mxStyleChange');
-      const isNegated = evt.getProperty('edit').changes.some(function test(s: any): boolean {
+      const edit = evt.getProperty('edit');
+      const isNotOnlyStyleChange = edit.changes.some((s: object) => s.constructor.name !== 'mxStyleChange');
+      const isNegated = edit.changes.some(function test(s: any): boolean {
         if (s.constructor.name === 'mxStyleChange' && s.previous !== null) {
           return (s.style as String).includes(EditorStyle.ADDITIONAL_CEG_CONNECTION_NEGATED_STYLE)
             !== ((s.previous as String).includes(EditorStyle.ADDITIONAL_CEG_CONNECTION_NEGATED_STYLE));
         }
         return false;
       });
-      if (!isStyleChange || isNegated) {
-        this.undoManager.undoableEditHappened(evt.getProperty('edit'));
+      if (isNotOnlyStyleChange || isNegated) {
+        this.undoManager.undoableEditHappened(edit);
       }
     };
     this.graph.getModel().addListener(mx.mxEvent.UNDO, listener);

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
@@ -125,7 +125,6 @@ export class ChangeTranslator {
         }
     }
 
-
     private async translateDelete(change: mxgraph.mxChildChange): Promise<void> {
         const deleteTool = this.toolProvider.tools.find(tool => (tool as DeleteToolBase).isDeleteTool === true) as DeleteToolBase;
         deleteTool.element = await this.getElement(change.child.id);


### PR DESCRIPTION
[Trello](https://trello.com/c/na2TSCLO/537-mxgraph-process-wird-eine-kante-mit-bedingung-im-prozessmodell-gel%C3%B6scht-und-anschlie%C3%9Fend-mit-undo-wiederhergestellt-dann-fehlt-d)