### PR TITLE
View is updated after a change, thus adding an edge shows the type-fi…

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -220,6 +220,7 @@ export class GraphicalEditor {
         edit.undo();
         this.changeTranslator.preventDataUpdates = false;
       } finally {
+        this.graph.getView().revalidate();
         this.undoService.setUndoEnabled(this.undoManager.canUndo());
         this.undoService.setRedoEnabled(this.undoManager.canRedo());
       }


### PR DESCRIPTION
[Trello](https://trello.com/c/VymV4ybD/536-mxgraph-ceg-der-typ-wird-nicht-automatisch-angezeigt-wenn-eine-zweite-kante-hinzugef%C3%BCgt-wird)

Type-dropdown is now shown if a second edge is added. (CEG)