### PR TITLE
Set center of zoom to top left corner

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -136,6 +136,7 @@ export class GraphicalEditor {
     mx.mxConnectionHandler.prototype.connectImage = new mx.mxImage('/assets/img/editor-tools/connector.png', 16, 16);
     mx.mxGraph.prototype.warningImage = new mx.mxImage('/assets/img/editor-tools/error_red.png', 19, 19);
     mx.mxGraphHandler.prototype['guidesEnabled'] = true;
+    mx.mxGraph.prototype.centerZoom = false;
 
     mx.mxEvent.disableContextMenu(this.graphContainerElement.nativeElement);
 


### PR DESCRIPTION
[Trello](https://trello.com/c/rQl1mP0l/541-mxgraph-zoom-in-chrome-setzt-den-zoomfokus-in-die-mitte-statt-in-die-linke-obere-ecke)