### PR TITLE
Undo an edge throws no error

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
@@ -329,7 +329,10 @@ export class ChangeTranslator {
         } else if (change['value']) {
             await this.translateEdgeValueChange(change as mxgraph.mxValueChange, connection);
         } else {
-            if (change.cell.source === null || change.cell.target === null) {
+            if (change['previous']) {
+                // Edge is undone
+                return;
+            } else if (change.cell.source === null || change.cell.target === null) {
                 throw new Error('No source or target');
             }
         }


### PR DESCRIPTION
[Trello](https://trello.com/c/afe8JTg3/542-mxgraph-hinzuf%C3%BCgen-einer-kante-und-anschlie%C3%9Fendes-r%C3%BCckg%C3%A4ngig-wirft-einen-fehler)

No error if undo edge