### PR TITLE
Changing default text node input size.

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-style.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-style.ts
@@ -45,7 +45,7 @@ export class EditorStyle {
 
 
     public static readonly TEXT_INPUT_STYLE = 'BASE_TEXT_INPUT';
-    private static readonly TEXT_INPUT_STYLE_STR = 'shape=rectangle;rounded=0;align=center;strokeColor=none;fillColor=none';
+    private static readonly TEXT_INPUT_STYLE_STR = 'shape=rectangle;rounded=0;align=center;strokeColor=#666666;fillColor=none';
     private static readonly TEXT_INPUT_STYLE_OBJ: Style = EditorStyle.createStyle(EditorStyle.TEXT_INPUT_STYLE_STR);
 
     public static readonly BASE_CEG_NODE_STYLE = 'BASE_CEG_NODE';

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
@@ -1,6 +1,7 @@
 import { mxgraph } from 'mxgraph';
 import { CEGConnection } from 'src/app/model/CEGConnection';
 import { CEGNode } from 'src/app/model/CEGNode';
+import { ProcessConnection } from 'src/app/model/ProcessConnection';
 import { Type } from 'src/app/util/type';
 import { CEGModel } from '../../../../../../../../model/CEGModel';
 import { IContainer } from '../../../../../../../../model/IContainer';
@@ -19,10 +20,9 @@ import { NodeNameConverterProvider } from '../../providers/conversion/node-name-
 import { CEGmxModelNode } from '../../providers/properties/ceg-mx-model-node';
 import { ShapeProvider } from '../../providers/properties/shape-provider';
 import { ToolProvider } from '../../providers/properties/tool-provider';
+import { VertexProvider } from '../../providers/properties/vertex-provider';
 import { EditorStyle } from '../editor-components/editor-style';
 import { StyleChanger } from './style-changer';
-import { VertexProvider } from '../../providers/properties/vertex-provider';
-import { ProcessConnection } from 'src/app/model/ProcessConnection';
 
 
 declare var require: any;
@@ -295,8 +295,16 @@ export class ChangeTranslator {
         }
     }
 
+    private isTextInputChange(change: mxgraph.mxTerminalChange | mxgraph.mxValueChange): boolean {
+        const cell = change.cell as mxgraph.mxCell;
+        return (cell.id.endsWith(VertexProvider.ID_SUFFIX_VARIABLE) || cell.id.endsWith(VertexProvider.ID_SUFFIX_CONDITION));
+    }
+
     private async translateNodeChange(change: mxgraph.mxTerminalChange | mxgraph.mxValueChange, element: IModelNode): Promise<void> {
         let cell = change.cell as mxgraph.mxCell;
+        if (this.isTextInputChange(change)) {
+            VertexProvider.adjustChildCellSize(cell, element.width);
+        }
         if (this.nodeNameConverter) {
             if (this.parentComponents[cell.getId()] !== undefined) {
                 // The changed node is a sublabel / child

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/providers/properties/vertex-provider.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/providers/properties/vertex-provider.ts
@@ -24,6 +24,9 @@ export class VertexProvider extends ProviderBase {
     public static ID_SUFFIX_CONDITION = '/condition';
     public static ID_SUFFIX_TYPE = '/type';
 
+    private static INITIAL_CHILD_NODE_X = 0.5;
+    private static EMPTY_CHILD_NODE_WIDTH = 50;
+
     constructor(element: IContainer, private graph: mxgraph.mxGraph,
         private shapeProvider: ShapeProvider, private nodeNameConverter: ConverterBase<any, CEGmxModelNode | string>) {
         super(element);
@@ -36,17 +39,32 @@ export class VertexProvider extends ProviderBase {
         this.graph.getModel().beginUpdate();
         const vertex = this.graph.insertVertex(parent, url, value, x, y, width, height, style);
         const l1 = this.graph.insertVertex(vertex, url + VertexProvider.ID_SUFFIX_VARIABLE, data.variable,
-            0, 0.15, width, (mx.mxConstants.DEFAULT_FONTSIZE), EditorStyle.TEXT_INPUT_STYLE, true);
+            VertexProvider.INITIAL_CHILD_NODE_X, 0.15, 0, (mx.mxConstants.DEFAULT_FONTSIZE), EditorStyle.TEXT_INPUT_STYLE, true);
         const l2 = this.graph.insertVertex(vertex, url + VertexProvider.ID_SUFFIX_CONDITION, data.condition,
-            0, 0.4, width, (mx.mxConstants.DEFAULT_FONTSIZE), EditorStyle.TEXT_INPUT_STYLE, true);
+            VertexProvider.INITIAL_CHILD_NODE_X, 0.4, 0, (mx.mxConstants.DEFAULT_FONTSIZE), EditorStyle.TEXT_INPUT_STYLE, true);
         const l3 = this.graph.insertVertex(vertex, url + VertexProvider.ID_SUFFIX_TYPE, data.type,
-            0, 0.65, width, (mx.mxConstants.DEFAULT_FONTSIZE), EditorStyle.TEXT_INPUT_STYLE, true);
+            VertexProvider.INITIAL_CHILD_NODE_X, 0.65, 0, (mx.mxConstants.DEFAULT_FONTSIZE), EditorStyle.TEXT_INPUT_STYLE, true);
+
+        VertexProvider.adjustChildCellSize(l1, width);
+        VertexProvider.adjustChildCellSize(l2, width);
 
         l1.isConnectable = () => false;
         l2.isConnectable = () => false;
         l3.isConnectable = () => false;
         this.graph.getModel().endUpdate();
         return vertex;
+    }
+
+    public static adjustChildCellSize(cell: mxgraph.mxCell, nodeWidth: number) {
+        const g = cell.getGeometry();
+        let x = VertexProvider.INITIAL_CHILD_NODE_X;
+        let w = 0;
+        const minWidth = VertexProvider.EMPTY_CHILD_NODE_WIDTH;
+        if (g.width < minWidth && (cell.value === '' || cell.value === null || cell.value === undefined)) {
+            x = x - (minWidth / nodeWidth) / 2;
+            w = minWidth;
+        }
+        cell.getGeometry().setRect(x, g.y, w, g.height);
     }
 
     public provideVertex(node: IModelNode, x?: number, y?: number): mxgraph.mxCell {


### PR DESCRIPTION
[Trello Card](https://trello.com/c/3uhZDnaB/564-fehler-knoten-kann-man-nur-ganz-am-oberen-oder-unteren-rand-verschieben)
