### PR TITLE
Fix testexport via csv

### DIFF
--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/CSVTestSpecificationExporter.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/CSVTestSpecificationExporter.java
@@ -50,14 +50,25 @@ public class CSVTestSpecificationExporter extends TestSpecificationExporterBase 
 	}
 
 	@Override
-	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments) {
+	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments,
+			List<TestParameter> parameters) {
 		StringJoiner joiner = new StringJoiner(ExportUtil.CSV_COL_SEP);
-		for (ParameterAssignment assignment : assignments) {
-			String assignmentValue = assignment.getCondition();
-			String characterToEscape = "=";
-			String escapeString = StringUtils.isEmpty(assignmentValue) ? ""
-					: escapeString(assignmentValue, characterToEscape);
-			joiner.add(StringUtils.wrap(escapeString + assignmentValue, ExportUtil.CSV_TEXT_WRAP));
+		for (TestParameter parameter : parameters) {
+			boolean added = false;
+			for (ParameterAssignment assignment : assignments) {
+				if (parameter.getName().equals(assignment.getParameter().getName())) {
+					added = true;
+					String assignmentValue = assignment.getCondition();
+					String characterToEscape = "=";
+					String escapeString = StringUtils.isEmpty(assignmentValue) ? ""
+							: escapeString(assignmentValue, characterToEscape);
+					joiner.add(StringUtils.wrap(escapeString + assignmentValue, ExportUtil.CSV_TEXT_WRAP));
+					break;
+				}
+			}
+			if (!added) {
+				joiner.add(StringUtils.wrap("", ExportUtil.CSV_TEXT_WRAP));
+			}
 		}
 		sb.append(joiner.toString());
 	}

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/JavaTestSpecificationExporter.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/JavaTestSpecificationExporter.java
@@ -68,7 +68,7 @@ public class JavaTestSpecificationExporter extends TestSpecificationExporterBase
 	}
 
 	@Override
-	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments) {
+	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments, List<TestParameter> parameters) {
 		for (ParameterAssignment pAssignment : assignments) {
 			appendParameterValue(sb, pAssignment);
 		}

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/JavascriptTestSpecificationExporter.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/JavascriptTestSpecificationExporter.java
@@ -57,7 +57,7 @@ public class JavascriptTestSpecificationExporter extends TestSpecificationExport
 	}
 
 	@Override
-	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments) {
+	protected void generateTestCaseParameterAssignments(StringBuilder sb, List<ParameterAssignment> assignments, List<TestParameter> parameters) {
 		for (ParameterAssignment pAssignment : assignments) {
 			appendParameterValue(sb, pAssignment);
 		}

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/TestSpecificationExporterBase.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/TestSpecificationExporterBase.java
@@ -64,7 +64,7 @@ public abstract class TestSpecificationExporterBase implements ITestExporter {
 		for (TestCase tc : getTestCases(testSpecification)) {
 			generateTestCaseHeader(sb, testSpecification, tc);
 			List<ParameterAssignment> assignments = getTestCaseParameterAssignments(tc);
-			generateTestCaseParameterAssignments(sb, assignments);
+			generateTestCaseParameterAssignments(sb, assignments, parameters);
 			generateTestCaseFooter(sb, tc);
 		}
 		generateFooter(sb, testSpecification);
@@ -120,7 +120,7 @@ public abstract class TestSpecificationExporterBase implements ITestExporter {
 	protected abstract void generateTestCaseHeader(StringBuilder sb, TestSpecification ts, TestCase tc);
 
 	protected abstract void generateTestCaseParameterAssignments(StringBuilder sb,
-			List<ParameterAssignment> assignments);
+			List<ParameterAssignment> assignments, List<TestParameter> parameters);
 
 	protected abstract String generateFileName(TestSpecification testSpecification);
 }


### PR DESCRIPTION
[Trello Card](https://trello.com/c/UBmvAcwB/561-export-der-testspezifikation-aus-prozessmodellen-ist-kaputt)

csv export should work now. It's not the most elegant way, but I have no better idea to solve it. If you have a better idea, share it with me ;)
