### PR TITLE
Using client date for export comments

### DIFF
--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/TestSpecificationExporterBase.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/exporters/TestSpecificationExporterBase.java
@@ -20,6 +20,9 @@ import com.specmate.testspecification.api.ITestExporter;
 /** Base class for Test Specification Exporters (aka "Skeletons") */
 public abstract class TestSpecificationExporterBase implements ITestExporter {
 
+	/** The date of the export */
+	private Date date;
+	
 	/** the language for the export */
 	protected String language;
 
@@ -36,6 +39,14 @@ public abstract class TestSpecificationExporterBase implements ITestExporter {
 	@Override
 	public String getLanguage() {
 		return language;
+	}
+	
+	public void setDate(Date date) {
+		this.date = date;
+	}
+	
+	public Date getDate() {
+		return this.date;
 	}
 
 	@Override
@@ -106,7 +117,11 @@ public abstract class TestSpecificationExporterBase implements ITestExporter {
 		sb.append("/*\n");
 		sb.append(" * Datum: ");
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
-		sb.append(sdf.format(new Date()));
+		Date exportDate = getDate();
+		if(exportDate == null) {
+			exportDate = new Date();
+		}
+		sb.append(sdf.format(exportDate));
 		sb.append("\n */\n\n");
 	}
 

--- a/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/services/TestExportService.java
+++ b/bundles/specmate-testspecification/src/com/specmate/testspecification/internal/services/TestExportService.java
@@ -1,5 +1,6 @@
 package com.specmate.testspecification.internal.services;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,10 +25,12 @@ import com.specmate.model.testspecification.TestSpecification;
 import com.specmate.model.testspecification.TestSpecificationSkeleton;
 import com.specmate.rest.RestResult;
 import com.specmate.testspecification.api.ITestExporter;
+import com.specmate.testspecification.internal.exporters.TestSpecificationExporterBase;
 
 /** Service that exports a test specification in various formats */
 @Component(immediate = true, service = IRestService.class)
 public class TestExportService extends RestServiceBase {
+	private static final String EXPORT_DATE_KEY = "exportDate";
 	private final String LANGUAGE_PARAM = "language";
 	private Map<String, ITestExporter> testSpecificationExporters = new HashMap<String, ITestExporter>();
 	private Map<String, ITestExporter> testProcedureExporters = new HashMap<String, ITestExporter>();
@@ -61,6 +64,12 @@ public class TestExportService extends RestServiceBase {
 		ITestExporter generator = null;
 		if (object instanceof TestSpecification) {
 			generator = testSpecificationExporters.get(language);
+			if(queryParams.containsKey(EXPORT_DATE_KEY) && generator instanceof TestSpecificationExporterBase) {
+				String exportDateParam = queryParams.getFirst(EXPORT_DATE_KEY);
+				Long timestamp = Long.parseLong(exportDateParam);
+				Date exportDate = new Date(timestamp);
+				((TestSpecificationExporterBase) generator).setDate(exportDate);
+			}
 		} else if (object instanceof TestProcedure) {
 			generator = testProcedureExporters.get(language);
 		}

--- a/web/src/app/modules/actions/modules/test-export-button/components/test-export-button.component.ts
+++ b/web/src/app/modules/actions/modules/test-export-button/components/test-export-button.component.ts
@@ -44,13 +44,16 @@ export class TestExportButton {
         }
 
         const data: TestSpecificationSkeleton = await this.dataService.performQuery(this._element.url, 'export',
-            { language: new LowerCasePipe().transform(this._lang)});
+            {
+                language: new LowerCasePipe().transform(this._lang),
+                exportDate: (new Date().getTime()).toString()
+            });
 
         if (data === undefined) {
             throw new Error('Could not load test specification skeleton for ' + this._lang);
         }
 
-        saveAs(new Blob([TestExportButton.UTF8_BOM + data.code], {type: 'text/plain;charset=utf-8'}), data.name);
+        saveAs(new Blob([TestExportButton.UTF8_BOM + data.code], { type: 'text/plain;charset=utf-8' }), data.name);
     }
 
     public get language(): string {


### PR DESCRIPTION
[Trello Card](https://trello.com/c/IfEsrW3L/569-falsches-datum-bei-exportierter-testspezifikation)
