### PR TITLE
Change the wiring of the ceg-generation

### DIFF
--- a/web/src/app/modules/actions/modules/ceg-model-generator-button/components/ceg-model-generator-button.component.ts
+++ b/web/src/app/modules/actions/modules/ceg-model-generator-button/components/ceg-model-generator-button.component.ts
@@ -78,7 +78,7 @@ export class CegModelGeneratorButton {
             await this.dataService.readElement(this.model.url, false);
             let modelContents = await this.dataService.readContents(this.model.url, false);
             this.selectedElementService.select(this.model);
-            this.graphicalEditorService.initGraphicalModel();
+            this.graphicalEditorService.triggerGraphicalModelInit();
 
             if (modelContents.length == 0) {
                 this.errorModal.open(this.translate.instant('modelGenerationFailed'));

--- a/web/src/app/modules/actions/modules/ceg-model-generator-button/components/ceg-model-generator-button.component.ts
+++ b/web/src/app/modules/actions/modules/ceg-model-generator-button/components/ceg-model-generator-button.component.ts
@@ -8,6 +8,7 @@ import { ConfirmationModal } from '../../../../notification/modules/modals/servi
 import { ElementProvider } from '../../../../views/main/editors/modules/graphical-editor/providers/properties/element-provider';
 import { SelectedElementService } from '../../../../views/side/modules/selected-element/services/selected-element.service';
 import { ErrorNotificationModalService } from '../../../../notification/modules/modals/services/error-notification-modal.service';
+import { GraphicalEditorService } from 'src/app/modules/views/main/editors/modules/graphical-editor/services/graphical-editor.service';
 
 @Component({
     moduleId: module.id.toString(),
@@ -54,7 +55,8 @@ export class CegModelGeneratorButton {
         private modal: ConfirmationModal,
         private errorModal: ErrorNotificationModalService,
         private translate: TranslateService,
-        private selectedElementService: SelectedElementService) { }
+        private selectedElementService: SelectedElementService,
+        private graphicalEditorService: GraphicalEditorService) { }
 
     public async generate(): Promise<void> {
         if (!this.enabled) {
@@ -76,7 +78,7 @@ export class CegModelGeneratorButton {
             await this.dataService.readElement(this.model.url, false);
             let modelContents = await this.dataService.readContents(this.model.url, false);
             this.selectedElementService.select(this.model);
-            this.dataService.elementChanged.emit(this.model.url);
+            this.graphicalEditorService.initGraphicalModel();
 
             if (modelContents.length == 0) {
                 this.errorModal.open(this.translate.instant('modelGenerationFailed'));

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -33,6 +33,7 @@ import { EditorPopup } from './editor-components/editor-popup';
 import { EditorStyle } from './editor-components/editor-style';
 import { ChangeTranslator } from './util/change-translator';
 import { StyleChanger } from './util/style-changer';
+import { GraphicalEditorService } from '../services/graphical-editor.service';
 
 declare var require: any;
 
@@ -72,7 +73,8 @@ export class GraphicalEditor {
     private selectedElementService: SelectedElementService,
     private validationService: ValidationService,
     private translate: TranslateService,
-    private undoService: UndoService) {
+    private undoService: UndoService,
+    private graphicalEditorService: GraphicalEditorService) {
 
     this.navigator.navigationStart.subscribe(() => {
       this.isInGraphTransition = true;
@@ -93,10 +95,9 @@ export class GraphicalEditor {
       this.redo();
     });
 
-    this.dataService.elementChanged.subscribe((url: string) => {
-      if (url === this.model.url) {
-        this.init();
-      }
+    this.graphicalEditorService.initModel.subscribe(async () => {
+      await this.init();
+      validationService.validateCurrent();
     });
   }
 

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/graphical-editor.module.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/graphical-editor.module.ts
@@ -5,6 +5,7 @@ import { MaximizeButtonModule } from '../maximize-button/maximize-button.module'
 import { ToolPalletteModule } from '../tool-pallette/tool-pallette.module';
 import { GraphicalEditor } from './components/graphical-editor.component';
 import { EditorGridButtonModule } from '../editor-grid-button/editor-grid-button.module';
+import { GraphicalEditorService } from './services/graphical-editor.service';
 
 @NgModule({
   imports: [
@@ -24,7 +25,7 @@ import { EditorGridButtonModule } from '../editor-grid-button/editor-grid-button
     GraphicalEditor
   ],
   providers: [
-    // SERVICES
+    GraphicalEditorService
   ],
   bootstrap: [
     // COMPONENTS THAT ARE BOOTSTRAPPED HERE

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/services/graphical-editor.service.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/services/graphical-editor.service.ts
@@ -1,0 +1,14 @@
+import { Injectable, EventEmitter } from '@angular/core';
+
+@Injectable()
+export class GraphicalEditorService {
+
+    public initModel: EventEmitter<void> = new EventEmitter<void>();
+
+    constructor() {
+    }
+
+    public initGraphicalModel(): void {
+        this.initModel.emit();
+    }
+}

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/services/graphical-editor.service.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/services/graphical-editor.service.ts
@@ -8,7 +8,7 @@ export class GraphicalEditorService {
     constructor() {
     }
 
-    public initGraphicalModel(): void {
+    public triggerGraphicalModelInit(): void {
         this.initModel.emit();
     }
 }


### PR DESCRIPTION
[Trello Card](https://trello.com/c/VsD9zob5/603-gibt-man-einen-text-bei-name-beschreibung-oder-modellanforderung-ein-validiert-der-validator-nach-jedem-zeichen-ausschalten)

I changed the wiring of the ceg-generation-button (PR #97), because a change of the name, description or model requirement always triggers a re-init of the complete editor. 
I add a new service to solve it. I'm not sure if this is much better from an architectural point of view.
