### PR TITLE
Removing textarea autosize for performance

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -45,7 +45,6 @@
     "mxgraph": "github:jgraph/mxgraph#12621211eed3495188c95bbc4b3020a1db451df5",
     "ng2-dragula": "2.1.1",
     "ngx-cookie": "4.1.2",
-    "ngx-textarea-autosize": "2.0.3",
     "ngx-translate-core": "11.0.3",
     "ngx-translate-extract": "1.0.0",
     "popper.js": "1.16.0",

--- a/web/src/app/modules/views/main/editors/modules/test-procedure-editor/components/test-step-row.component.html
+++ b/web/src/app/modules/views/main/editors/modules/test-procedure-editor/components/test-step-row.component.html
@@ -5,17 +5,17 @@
     <td>{{getPosition(testStep)}}</td>
     <td>
         <div class="input-group input-group-sm">
-            <textarea formControlName="name" type="text" class="tableInput form-control form-control-sm" autosize></textarea>
+            <textarea formControlName="name" type="text" class="tableInput form-control form-control-sm"></textarea>
         </div>
     </td>
     <td>
         <div class="input-group input-group-sm">
-            <textarea formControlName="description" type="text" class="tableInput form-control form-control-sm" autosize></textarea>
+            <textarea formControlName="description" type="text" class="tableInput form-control form-control-sm"></textarea>
         </div>
     </td>
     <td>
         <div class="input-group input-group-sm">
-            <textarea formControlName="expectedOutcome" type="text" class="tableInput form-control form-control-sm" autosize></textarea>
+            <textarea formControlName="expectedOutcome" type="text" class="tableInput form-control form-control-sm"></textarea>
         </div>
     </td>
     <td>

--- a/web/src/app/modules/views/main/editors/modules/test-procedure-editor/test-procedure-editor.module.ts
+++ b/web/src/app/modules/views/main/editors/modules/test-procedure-editor/test-procedure-editor.module.ts
@@ -8,7 +8,6 @@ import { MaximizeButtonModule } from '../maximize-button/maximize-button.module'
 import { TestCaseParameterMappingModule } from '../test-case-parameter-mapping/test-case-parameter-mapping.module';
 import { TestProcedureEditor } from './components/test-procedure-editor.component';
 import { TestStepRow } from './components/test-step-row.component';
-import { TextareaAutosizeModule } from 'ngx-textarea-autosize';
 
 @NgModule({
   imports: [
@@ -20,8 +19,7 @@ import { TextareaAutosizeModule } from 'ngx-textarea-autosize';
     TestCaseParameterMappingModule,
     FormsModule,
     SpecmateSharedModule,
-    ReactiveFormsModule,
-    TextareaAutosizeModule
+    ReactiveFormsModule
   ],
   declarations: [
     // COMPONENTS IN THIS MODULE

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-condition-form.component.html
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-condition-form.component.html
@@ -1,5 +1,5 @@
 <span [formGroup]="formGroup" *ngIf="isInitialized">
     <div class="input-group input-group-sm">
-        <textarea formControlName="condition" type="text" class="form-control form-control-sm  tableInput" autosize></textarea>
+        <textarea formControlName="condition" type="text" class="form-control form-control-sm  tableInput"></textarea>
     </div>
 </span>

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-name-form.component.html
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-case-name-form.component.html
@@ -1,5 +1,5 @@
 <span [formGroup]="formGroup">
     <div class="input-group  input-group-sm">
-        <textarea formControlName="name" type="text" class="form-control form-control-sm tableInput" autosize></textarea>
+        <textarea formControlName="name" type="text" class="form-control form-control-sm tableInput"></textarea>
     </div>
 </span>

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-parameter-form.component.html
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/components/test-parameter-form.component.html
@@ -1,6 +1,6 @@
 <span [formGroup]="formGroup">
     <div class="input-group input-group-sm">
-        <textarea formControlName="name" type="text" class="form-control form-control-sm tableInput" autosize></textarea>
+        <textarea formControlName="name" type="text" class="form-control form-control-sm tableInput"></textarea>
         <div class="input-group-append">
             <button title="Delete parameter" class="btn btn-sm btn-outline-danger" [class.disabled]="!deleteColumnEnabled" (click)="deleteParameter()"><i class="fa fa-trash"></i></button>
         </div>

--- a/web/src/app/modules/views/main/editors/modules/test-specification-editor/test-specification-editor.module.ts
+++ b/web/src/app/modules/views/main/editors/modules/test-specification-editor/test-specification-editor.module.ts
@@ -10,7 +10,6 @@ import { TestCaseNameForm } from './components/test-case-name-form.component';
 import { TestCaseRow } from './components/test-case-row.component';
 import { TestParameterForm } from './components/test-parameter-form.component';
 import { TestSpecificationEditor } from './components/test-specification-editor.component';
-import { TextareaAutosizeModule } from 'ngx-textarea-autosize';
 
 @NgModule({
   imports: [
@@ -21,8 +20,7 @@ import { TextareaAutosizeModule } from 'ngx-textarea-autosize';
     FormsModule,
     ReactiveFormsModule,
     SpecmateSharedModule,
-    NavigatorModule,
-    TextareaAutosizeModule
+    NavigatorModule
   ],
   declarations: [
     // COMPONENTS IN THIS MODULE


### PR DESCRIPTION
[Trello Card](https://trello.com/c/gegs2wVW/605-testspezifikationseditor-extrem-langsam-anlegen-von-neuen-testf%C3%A4llen-und-editieren-sehr-m%C3%BChsam-da-editor-nicht-performant-reagie)
