### PR TITLE
Enable STRG + Z/Y in modeleditor

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-key-handler.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/editor-components/editor-key-handler.ts
@@ -1,4 +1,5 @@
 import { mxgraph } from 'mxgraph'; // Typings only - no code!
+import { UndoService } from 'src/app/modules/actions/modules/common-controls/services/undo.service';
 
 declare var require: any;
 
@@ -10,7 +11,7 @@ const mx: typeof mxgraph = require('mxgraph')({
  * Keybindings for the graphical editor
  */
 export class EditorKeyHandler {
-    public static initKeyHandler(graph: mxgraph.mxGraph) {
+    public static initKeyHandler(graph: mxgraph.mxGraph, undoService: UndoService) {
         let keyHandler = new mx.mxKeyHandler(graph);
 
         // Support Mac command-key
@@ -66,6 +67,22 @@ export class EditorKeyHandler {
                 const sel = EditorKeyHandler.getFilteredSelectedCells(graph);
                 mx.mxClipboard.copy(graph, sel);
                 EditorKeyHandler.deleteSelectedCells(graph);
+            }
+        });
+
+        // Ctrl+Z
+        keyHandler.bindControlKey(90, (evt: KeyboardEvent) => {
+            EditorKeyHandler.stopEvent(evt);
+            if (graph.isEnabled()) {
+                undoService.undo();
+            }
+        });
+
+        // Ctrl+Y
+        keyHandler.bindControlKey(89, (evt: KeyboardEvent) => {
+            EditorKeyHandler.stopEvent(evt);
+            if (graph.isEnabled()) {
+                undoService.redo();
             }
         });
         return keyHandler;

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/graphical-editor.component.ts
@@ -295,7 +295,7 @@ export class GraphicalEditor {
 
     VertexProvider.initRenderer(this.graph);
     EditorStyle.initEditorStyles(this.graph);
-    EditorKeyHandler.initKeyHandler(this.graph);
+    EditorKeyHandler.initKeyHandler(this.graph, this.undoService);
     this.initUndoManager();
 
     this.popup = new EditorPopup(this.graph, this.contents, this.translate);


### PR DESCRIPTION
[Trello Card](https://trello.com/c/Q48EQitX/636-str-z-r%C3%BCckg%C3%A4ngig-im-modelleditor)

Only for the model-editor, because I don't know, if we have keyboardhandling in the rest of Specmate