### PR TITLE
Fix: Error with two sentences with comma in CEG-generation

### DIFF
--- a/bundles/specmate-model-generation/src/com/specmate/modelgeneration/legacy/GermanPatternMatcher.java
+++ b/bundles/specmate-model-generation/src/com/specmate/modelgeneration/legacy/GermanPatternMatcher.java
@@ -124,7 +124,7 @@ public class GermanPatternMatcher implements ICauseEffectPatternMatcher {
 				positionComma = token.getBegin();
 			}
 		}
-		return positionComma;
+		return positionComma - sentence.getBegin();
 	}
 
 	private boolean hasVerbPhraseBeforeAndAfterPosition(JCas jCas, Sentence sentence, int positionComma) {


### PR DESCRIPTION
[Trello Card](https://trello.com/c/tsFyXbbi/643-ceg-generation-de-fehler-bei-zwei-s%C3%A4tzen-mit-komma)
