### PR TITLE
Prevent xss

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/xss-encoder.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/xss-encoder.ts
@@ -1,0 +1,5 @@
+
+export function xssEncode(text: string): string {
+    let doc = (new DOMParser().parseFromString(text, 'text/html'));
+    return doc.documentElement.textContent;
+}

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/converters/process-node-to-name-converter.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/converters/process-node-to-name-converter.ts
@@ -2,21 +2,22 @@ import { IContainer } from '../../../../../../../model/IContainer';
 import { ConverterBase } from './converter-base';
 import { Type } from 'src/app/util/type';
 import { ProcessConnection } from 'src/app/model/ProcessConnection';
+import { xssEncode } from '../components/util/xss-encoder';
 
 
 type ProcessNodeOrConnection = { name: string } | { condition: string };
 export class ProcessNodeToNameConverter extends ConverterBase<ProcessNodeOrConnection, string> {
     public convertTo(item: IContainer): string {
         if (Type.is(item, ProcessConnection)) {
-            return (item as ProcessConnection).condition;
+            return xssEncode((item as ProcessConnection).condition);
         }
-        return item.name;
+        return xssEncode(item.name);
     }
 
     public convertFrom(value: string, item?: ProcessNodeOrConnection): ProcessNodeOrConnection {
         if (item['condition'] !== undefined) {
-            return { condition: value };
+            return { condition: xssEncode(value) };
         }
-        return { name: value };
+        return { name: xssEncode(value) };
     }
 }

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/providers/properties/ceg-mx-model-node.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/providers/properties/ceg-mx-model-node.ts
@@ -1,6 +1,17 @@
+import { xssEncode } from '../../components/util/xss-encoder';
+
 export class CEGmxModelNode {
     public static VARIABLE_KEY = 'variable';
     public static CONDITION_KEY = 'condition';
     public static TYPE_KEY = 'type';
-    constructor(public variable: string, public condition: string, public type: string) {}
+
+    public variable: string;
+    public condition: string;
+    public type: string;
+
+    constructor(public _variable: string, public _condition: string, public _type: string) {
+        this.variable = xssEncode(_variable);
+        this.condition = xssEncode(_condition);
+        this.type = xssEncode(_type);
+    }
 }

--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/providers/properties/ceg-mx-model-node.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/providers/properties/ceg-mx-model-node.ts
@@ -12,6 +12,6 @@ export class CEGmxModelNode {
     constructor(public _variable: string, public _condition: string, public _type: string) {
         this.variable = xssEncode(_variable);
         this.condition = xssEncode(_condition);
-        this.type = xssEncode(_type);
+        this.type = _type;
     }
 }


### PR DESCRIPTION
[Trello Card](https://trello.com/c/5bz5FJ9G/616-xss-verhinden)

Second try to avoid xss. It only remove xss content in mx-graph. This leads to inconsistent data in mx-graph and the right properties window. But it only occurs if someone wants to use html/js code, so I would say it's no big problem.