### PR TITLE
Updating frame in editor on property changes

### DIFF
--- a/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
+++ b/web/src/app/modules/views/main/editors/modules/graphical-editor/components/util/change-translator.ts
@@ -472,6 +472,11 @@ export class ChangeTranslator {
                             graph.getModel().beginUpdate();
                             try {
                                 graph.model.setValue(child, val);
+                                let width = child.geometry.width;
+                                if (width <= 0) {
+                                    width = this.shapeProvider.getInitialSize(changedElement).width;
+                                }
+                                VertexProvider.adjustChildCellSize(child, width);
                             }
                             finally {
                                 graph.getModel().endUpdate();


### PR DESCRIPTION
[Trello Card](https://trello.com/c/1evD2NCV/655-rahmen-bei-leeren-knoten-verschwindet-nicht)
