### PR TITLE
adds feature to define config 'maxprojects'

### DIFF
--- a/bundles/specmate-connectors-api/src/com/specmate/connectors/api/IMultiProject.java
+++ b/bundles/specmate-connectors-api/src/com/specmate/connectors/api/IMultiProject.java
@@ -27,4 +27,10 @@ public interface IMultiProject {
 	 * config.
 	 */
 	Map<String, String> getTemplateConfigEntries();
+	
+	
+	/**
+	 * Returns the config value for maxprojects
+	 */
+	int getMaxNumberOfProjectsConfig();
 }

--- a/bundles/specmate-connectors-api/src/com/specmate/connectors/api/IProjectConfigService.java
+++ b/bundles/specmate-connectors-api/src/com/specmate/connectors/api/IProjectConfigService.java
@@ -36,6 +36,9 @@ public interface IProjectConfigService {
 	/** The prefix for multiproject configuration keys */
 	public static final String KEY_MULTIPROJECT_PROJECTNAMEPATTERN = "projectnamepattern";
 	
+	/** The key for max number of projects **/
+	public static final String KEY_MULTIPROJECT_MAXNUMBEROFPROJECTS = "maxprojects";
+	
 	/** The prefix for multiproject configuration keys */
 	public static final String KEY_MULTIPROJECT_TEMPLATE= "template";
 	

--- a/bundles/specmate-connectors/src/com/specmate/connectors/config/ProjectConfigService.java
+++ b/bundles/specmate-connectors/src/com/specmate/connectors/config/ProjectConfigService.java
@@ -192,6 +192,13 @@ public class ProjectConfigService implements IProjectConfigService {
 		if (projectNamePattern != null) {
 			multiProjectConfig.put(IProjectConfigService.KEY_MULTIPROJECT_PROJECTNAMEPATTERN, projectNamePattern);
 		}
+		
+		// multiproject.<projectname>.maxprojects
+		String maxprojects = configService.getConfigurationProperty(IProjectConfigService.MULTIPROJECT_PREFIX
+				+ multiProjectID + "." + IProjectConfigService.KEY_MULTIPROJECT_MAXNUMBEROFPROJECTS);
+		if (maxprojects != null) {
+			multiProjectConfig.put(IProjectConfigService.KEY_MULTIPROJECT_MAXNUMBEROFPROJECTS, maxprojects);
+		}
 
 		// multiproject.<projectname>.template.*
 		Set<Entry<Object, Object>> templateConfigEntries = configService

--- a/bundles/specmate-connectors/src/com/specmate/connectors/internal/MultiConnectorService.java
+++ b/bundles/specmate-connectors/src/com/specmate/connectors/internal/MultiConnectorService.java
@@ -92,10 +92,17 @@ public class MultiConnectorService {
 			for (IMultiConnector multiConnector : multiConnectorService.getMultiConnectors()) {
 
 				logService.log(LogService.LOG_INFO, "Syncing multi connector " + multiConnector.getId());
+				
+				int maxNoProjects = multiConnector.getMultiProject().getMaxNumberOfProjectsConfig();
+				int noProjects = 0;
 
 				try {
 					for (Map.Entry<String, Map<String, String>> projectConfigMapEntry : multiConnector
 							.getProjectConfigs().entrySet()) {
+												
+						if (noProjects++ >= maxNoProjects ) {
+							break;
+						}
 
 						String technicalProjectId = projectConfigMapEntry.getKey();
 						Map<String, String> projectConfig = projectConfigMapEntry.getValue();
@@ -134,8 +141,7 @@ public class MultiConnectorService {
 							// trigger project creation.
 							// this could be removed in case ProjectConfigService would monitor the config!
 							projectConfigService.configureProjects(new String[] { specmateProjectId });
-						}
-
+						} 
 					}
 				} catch (SpecmateException e) {
 					logService.log(LogService.LOG_ERROR, "Error syncing projects for " + multiConnector.getId(), e);

--- a/bundles/specmate-connectors/src/com/specmate/connectors/internal/MultiProjectImpl.java
+++ b/bundles/specmate-connectors/src/com/specmate/connectors/internal/MultiProjectImpl.java
@@ -36,6 +36,12 @@ public class MultiProjectImpl implements IMultiProject {
 	/** The template config entries for thiis multi project **/
 	private Map<String, String> templateConfigEntries;
 
+	/**
+	 * The maximum number of projects to handle. Used to keep the number of projects
+	 * low. E.g., for testing and demo purposes.
+	 **/
+	private int maxNumberOfProjects = Integer.MAX_VALUE;
+
 	@Activate
 	public void activate(Map<String, Object> properties) throws SpecmateInternalException {
 
@@ -45,6 +51,16 @@ public class MultiProjectImpl implements IMultiProject {
 		}
 
 		projectNamePattern = (String) properties.get(IProjectConfigService.KEY_MULTIPROJECT_PROJECTNAMEPATTERN);
+
+		String intString = (String) properties.get(IProjectConfigService.KEY_MULTIPROJECT_MAXNUMBEROFPROJECTS);
+		try {
+			if (intString != null) {
+				maxNumberOfProjects = Integer.parseInt(intString);
+			}
+		} catch (NumberFormatException nfe) {
+			throw new SpecmateInternalException(ErrorCode.CONFIGURATION, "Config value for "
+					+ IProjectConfigService.KEY_MULTIPROJECT_MAXNUMBEROFPROJECTS + " not valid: '" + intString + "'");
+		}
 
 		retrieveTemplateConfigEntries(properties);
 
@@ -100,5 +116,10 @@ public class MultiProjectImpl implements IMultiProject {
 	@Override
 	public String getProjectNamePattern() {
 		return projectNamePattern;
+	}
+
+	@Override
+	public int getMaxNumberOfProjectsConfig() {	
+		return maxNumberOfProjects;
 	}
 }

--- a/bundles/specmate-jira-connector/src/com/specmate/connectors/jira/config/JiraConfigConstants.java
+++ b/bundles/specmate-jira-connector/src/com/specmate/connectors/jira/config/JiraConfigConstants.java
@@ -15,10 +15,6 @@ public class JiraConfigConstants {
 	public static final String KEY_JIRA_CHILDREN_SQL = "jira.childrenJQL";
 	public static final String KEY_JIRA_WITH_FOLDERS = "jira.withFolders";
 	public static final Object KEY_JIRA_CACHE_TIME = "jira.cacheTime";
-	
-	// TODO this must be a property of the project (not a property of the connector)
-	// e.g., 'multiproject.localJira.projectsprefix'
-	public static final String KEY_JIRA_MULTIPROJECT_PREFIX = "jira.projectprefix";
-	
+
 	public static final String KEY_JIRA_MULTIPROJECT_TEMPLATE_PREFIX = "jira.template.";
 }


### PR DESCRIPTION
Adds new feature: Define a maximum of projects a multiproject shall generate.

This feature is just for testing and demo purposes. 

**New config entries (optional);**
```
...
multiproject.<multiproject-id>.maxprojects = <int-value>
...
```

**Warning:**
This implementation is rather simple. We just take the first x projects which are reported from the multi connector.
However, thereby the multi project service will be confused easily if the set of reported projects from the multi connector changes.