### PR TITLE
bug fix: handling exceptions in scheduler tasks

### DIFF
--- a/bundles/specmate-connectors/src/com/specmate/connectors/internal/ConnectorService.java
+++ b/bundles/specmate-connectors/src/com/specmate/connectors/internal/ConnectorService.java
@@ -72,7 +72,7 @@ public class ConnectorService {
 					SchedulerTask connectorRunnable = new ConnectorTask(connectorService, transaction, logService);
 					connectorRunnable.run();
 					modelSearchService.startReIndex();
-					Scheduler scheduler = new Scheduler();
+					Scheduler scheduler = new Scheduler(logService);
 					scheduler.schedule(connectorRunnable, SchedulerIteratorFactory.create(schedule));
 				} catch (SpecmateException e) {
 					e.printStackTrace();

--- a/bundles/specmate-connectors/src/com/specmate/connectors/internal/MultiConnectorService.java
+++ b/bundles/specmate-connectors/src/com/specmate/connectors/internal/MultiConnectorService.java
@@ -54,7 +54,7 @@ public class MultiConnectorService {
 			return;
 		}
 
-		Scheduler scheduler = new Scheduler();
+		Scheduler scheduler = new Scheduler(logService);
 		scheduler.schedule(new MultiConnectorTask(this, logService), SchedulerIteratorFactory.create(schedule));
 	}
 

--- a/bundles/specmate-jira-connector/src/com/specmate/connectors/jira/internal/services/JiraUtil.java
+++ b/bundles/specmate-jira-connector/src/com/specmate/connectors/jira/internal/services/JiraUtil.java
@@ -15,6 +15,7 @@ import com.atlassian.jira.rest.client.api.domain.BasicProject;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 import com.specmate.common.exception.SpecmateAuthorizationException;
 import com.specmate.common.exception.SpecmateException;
+import com.specmate.common.exception.SpecmateInternalException;
 import com.specmate.model.testspecification.TestStep;
 
 public class JiraUtil {
@@ -39,6 +40,13 @@ public class JiraUtil {
 				return false;
 			}
 			return false;
+		} catch (RuntimeException rte) {
+			/*
+			 * catch all other types of network exceptions which are hidden as
+			 * RuntimeException by the atlassian library
+			 */
+			throw new SpecmateInternalException(com.specmate.model.administration.ErrorCode.JIRA,
+					"There was an error connecting to Jira.", rte);
 		} finally {
 			if (client != null) {
 				try {
@@ -55,7 +63,8 @@ public class JiraUtil {
 	/**
 	 * Gets a list of all project-keys a given pair of credentials has access to.
 	 */
-	public static List<String> getProjects(String serverUrl, String username, String password) throws SpecmateException {
+	public static List<String> getProjects(String serverUrl, String username, String password)
+			throws SpecmateException {
 		JiraRestClient client = null;
 		try {
 
@@ -76,7 +85,15 @@ public class JiraUtil {
 				return null;
 			}
 			return null;
+		} catch (RuntimeException rte) {
+			/*
+			 * catch all other types of network exceptions which are hidden as
+			 * RuntimeException by the atlassian library
+			 */
+			throw new SpecmateInternalException(com.specmate.model.administration.ErrorCode.JIRA,
+					"There was an error connecting to Jira.", rte);
 		} finally {
+
 			if (client != null) {
 				try {
 					client.close();

--- a/bundles/specmate-metrics/src/com/specmate/metrics/internal/UserMetricService.java
+++ b/bundles/specmate-metrics/src/com/specmate/metrics/internal/UserMetricService.java
@@ -12,6 +12,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.log.LogService;
 
 import com.specmate.scheduler.*;
 import com.specmate.common.exception.SpecmateException;
@@ -25,6 +26,7 @@ import com.specmate.usermodel.UsermodelFactory;
 @Component(immediate=true)
 public class UserMetricService implements IUserMetricsService {
 
+	private LogService logService;
 	private IPersistencyService persistencyService;
 	private IMetricsService metricsService;
 	private IView sessionView;
@@ -75,7 +77,7 @@ public class UserMetricService implements IUserMetricsService {
 			String scheduleDay = "day 23 59 59";
 			SchedulerTask dailyMetricTask = new MetricTask(specmate_current_day);
 			//metricRunnable.run();
-			Scheduler scheduler = new Scheduler();
+			Scheduler scheduler = new Scheduler(logService);
 			scheduler.schedule(dailyMetricTask, SchedulerIteratorFactory.create(scheduleDay));
 			// Get the reseted counter back
 			specmate_current_day = ((MetricTask) dailyMetricTask).getGauge();
@@ -83,7 +85,7 @@ public class UserMetricService implements IUserMetricsService {
 			String scheduleWeek = "week 23 59 59";
 			SchedulerTask weeklyMetricTask = new MetricTask(specmate_current_week);
 			//metricRunnableWeek.run();
-			Scheduler schedulerWeek = new Scheduler();
+			Scheduler schedulerWeek = new Scheduler(logService);
 			schedulerWeek.schedule(weeklyMetricTask, SchedulerIteratorFactory.create(scheduleWeek, getNextSunday()));
 			// Get the reseted counter back
 			specmate_current_week = ((MetricTask) weeklyMetricTask).getGauge();
@@ -91,7 +93,7 @@ public class UserMetricService implements IUserMetricsService {
 			String scheduleMonth = "monthlastday 23 59 59";
 			SchedulerTask monthlyMetricTask = new MetricTask(specmate_current_month);
 			//metricRunnableMonth.run();
-			Scheduler schedulerMonth = new Scheduler();
+			Scheduler schedulerMonth = new Scheduler(logService);
 			schedulerMonth.schedule(monthlyMetricTask, SchedulerIteratorFactory.create(scheduleMonth));
 			// Get the reseted counter back
 			specmate_current_month = ((MetricTask) monthlyMetricTask).getGauge();
@@ -99,7 +101,7 @@ public class UserMetricService implements IUserMetricsService {
 			String scheduleYear = "year 23 59 59";
 			SchedulerTask yearlyMetricTask = new MetricTask(specmate_current_year);
 			//metricRunnableYear.run();
-			Scheduler schedulerYear = new Scheduler();
+			Scheduler schedulerYear = new Scheduler(logService);
 			schedulerYear.schedule(yearlyMetricTask, SchedulerIteratorFactory.create(scheduleYear, getLastDayOfYear()));
 			// Get the reseted counter back
 			specmate_current_year = ((MetricTask) yearlyMetricTask).getGauge();
@@ -256,5 +258,10 @@ public class UserMetricService implements IUserMetricsService {
 	@Reference 
 	public void setPersistencyService(IPersistencyService persistencyService) {
 		this.persistencyService = persistencyService;
+	}	
+
+	@Reference
+	public void setLogService(LogService logService) {
+		this.logService = logService;
 	}
 }

--- a/bundles/specmate-scheduler/bnd.bnd
+++ b/bundles/specmate-scheduler/bnd.bnd
@@ -4,4 +4,5 @@ Export-Package: \
 -buildpath: \
 	specmate-common;version=latest,\
 	specmate-model-gen;version=latest,\
-	org.apache.servicemix.bundles.junit
+	org.apache.servicemix.bundles.junit,\
+	org.eclipse.osgi.services;version='3.9.0'

--- a/bundles/specmate-scheduler/bnd.bnd
+++ b/bundles/specmate-scheduler/bnd.bnd
@@ -5,4 +5,5 @@ Export-Package: \
 	specmate-common;version=latest,\
 	specmate-model-gen;version=latest,\
 	org.apache.servicemix.bundles.junit,\
-	org.eclipse.osgi.services
+	org.eclipse.osgi.services,\
+	osgi.core;version=6.0

--- a/bundles/specmate-scheduler/bnd.bnd
+++ b/bundles/specmate-scheduler/bnd.bnd
@@ -5,4 +5,4 @@ Export-Package: \
 	specmate-common;version=latest,\
 	specmate-model-gen;version=latest,\
 	org.apache.servicemix.bundles.junit,\
-	org.eclipse.osgi.services;version='3.9.0'
+	org.eclipse.osgi.services


### PR DESCRIPTION
The following bug exists in the specmate scheduler infrastructure:

**Situation:** An exception is thrown within the `run()` method of a scheduler task
**Expected behaviour:** Scheduling run is terminated. Scheduler tasks is rescheduled.
**Actual behaviour:** Scheduler run is terminated. Scheduler task is **not** rescheduled.

This pull request provides a fix for this bug. Furthermore, it improves the error handling of `JiraUtil`