### PR TITLE
Hyphenation

### DIFF
--- a/web/src/assets/i18n/de.json
+++ b/web/src/assets/i18n/de.json
@@ -69,7 +69,7 @@
 	"ReferencedParameters": "Referenzierte Parameter",
 	"RelatedRequirements": "Zugehörige Anforderungen",
 	"Requirement": "Anforderung",
-	"RequirementDescription": "Anforderungsbeschreibung",
+	"RequirementDescription": "Beschreibung",
 	"RequirementID": "Anforderungs-ID",
 	"Responsibilities": "Verantwortlichkeiten",
 	"Status": "Status",

--- a/web/src/assets/i18n/gb.json
+++ b/web/src/assets/i18n/gb.json
@@ -69,7 +69,7 @@
 	"ReferencedParameters": "Referenced Parameters",
 	"RelatedRequirements": "Related Requirements",
 	"Requirement": "Requirement",
-	"RequirementDescription": "Requirements Description",
+	"RequirementDescription": "Description",
 	"RequirementID": "Requirement ID",
 	"Responsibilities": "Responsibilities",
 	"Status": "Status",


### PR DESCRIPTION
Closes #371
Already implemented in PR #377, See https://github.com/qualicen/specmate/blob/ac824f3695d853554f1c42337a02f5f8fdaf4200/web/src/assets/scss/specmate.extensions.scss#L13

Only Edge does not support hyphen:auto.(Hopefully soon). This is the reason we shorten the word.
